### PR TITLE
when the token is invalid procedure should immediately return

### DIFF
--- a/system/middleware.go
+++ b/system/middleware.go
@@ -113,11 +113,13 @@ func (application *Application) ApplyCsrfProtection(c *web.C, h http.Handler) ht
 		if c.Env["IsXhr"].(bool) {
 			if !isValidToken(csrfToken, r.Header.Get(csrfProtection.Header)) {
 				http.Error(w, "Invalid Csrf Header", http.StatusBadRequest)
+				return
 			}
 		} else {
 			if isCsrfProtectionMethodForNoXhr(r.Method) {
 				if !isValidToken(csrfToken, r.PostFormValue(csrfProtection.Key)) {
 					http.Error(w, "Invalid Csrf Token", http.StatusBadRequest)
+					return
 				}
 			}
 		}


### PR DESCRIPTION
in the case CSRF token is invalid, this procedure should immediately return here.
otherwise, Controller actions would be executed if the token was valid or not.
